### PR TITLE
Simultaneous serial and internal control of throttle and axes

### DIFF
--- a/KSPSerialIO/KSPIO.cs
+++ b/KSPSerialIO/KSPIO.cs
@@ -123,18 +123,25 @@ namespace KSPSerialIO
     [KSPAddon(KSPAddon.Startup.MainMenu, false)]
     public class SettingsNStuff : MonoBehaviour
     {
+		public enum ControlType {
+			InternalTotal = 0, // Always use value provided by KSP.
+			ExternalTotal = 1, // Always use value from serial packet, overriding internal value.
+			InternalPriority = 2, // Only use external value if internal is 0.
+			ExternalPriority = 3, // Only use internal value if external is 0.
+		}
+
         public static PluginConfiguration cfg = PluginConfiguration.CreateForType<SettingsNStuff>();
         public static string DefaultPort;
         public static double refreshrate;
         public static int HandshakeDelay;
         public static int BaudRate;
-        public static bool ThrottleEnable;
-        public static bool PitchEnable;
-        public static bool RollEnable;
-        public static bool YawEnable;
-        public static bool TXEnable;
-        public static bool TYEnable;
-        public static bool TZEnable;
+		public static ControlType ThrottleEnable;
+		public static ControlType PitchEnable;
+		public static ControlType RollEnable;
+		public static ControlType YawEnable;
+		public static ControlType TXEnable;
+		public static ControlType TYEnable;
+		public static ControlType TZEnable;
         public static double SASTol;
 
         void Awake()
@@ -157,25 +164,25 @@ namespace KSPSerialIO
             HandshakeDelay = cfg.GetValue<int>("HandshakeDelay");
             print("KSPSerialIO: Handshake Delay = " + HandshakeDelay.ToString());
 
-            ThrottleEnable = cfg.GetValue<bool>("ThrottleEnable");
+			ThrottleEnable = cfg.GetValue<SettingsNStuff.ControlType>("ThrottleEnable");
             print("KSPSerialIO: Throttle Enable = " + ThrottleEnable.ToString());
 
-            PitchEnable = cfg.GetValue<bool>("PitchEnable");
+			PitchEnable = cfg.GetValue<SettingsNStuff.ControlType>("PitchEnable");
             print("KSPSerialIO: Pitch Enable = " + PitchEnable.ToString());
 
-            RollEnable = cfg.GetValue<bool>("RollEnable");
+			RollEnable = cfg.GetValue<SettingsNStuff.ControlType>("RollEnable");
             print("KSPSerialIO: Roll Enable = " + RollEnable.ToString());
 
-            YawEnable = cfg.GetValue<bool>("YawEnable");
+			YawEnable = cfg.GetValue<SettingsNStuff.ControlType>("YawEnable");
             print("KSPSerialIO: Yaw Enable = " + YawEnable.ToString());
 
-            TXEnable = cfg.GetValue<bool>("TXEnable");
+			TXEnable = cfg.GetValue<SettingsNStuff.ControlType>("TXEnable");
             print("KSPSerialIO: Translate X Enable = " + TXEnable.ToString());
 
-            TYEnable = cfg.GetValue<bool>("TYEnable");
+			TYEnable = cfg.GetValue<SettingsNStuff.ControlType>("TYEnable");
             print("KSPSerialIO: Translate Y Enable = " + TYEnable.ToString());
 
-            TZEnable = cfg.GetValue<bool>("TZEnable");
+			TZEnable = cfg.GetValue<SettingsNStuff.ControlType>("TZEnable");
             print("KSPSerialIO: Translate Z Enable = " + TZEnable.ToString());
 
             SASTol = cfg.GetValue<double>("SASTol");
@@ -1011,27 +1018,128 @@ namespace KSPSerialIO
 
         private void AxisInput(FlightCtrlState s)
         {
+			switch (SettingsNStuff.ThrottleEnable)
+			{
+			case SettingsNStuff.ControlType.ExternalTotal:
+				s.mainThrottle = KSPSerialPort.VControls.Throttle;
+				break;
+			case SettingsNStuff.ControlType.InternalPriority:
+				if (s.mainThrottle == 0)
+				{
+					s.mainThrottle = KSPSerialPort.VControls.Throttle;
+				}
+				break;
+			case SettingsNStuff.ControlType.ExternalPriority:
+				if (KSPSerialPort.VControls.Throttle != 0)
+				{
+					s.mainThrottle = KSPSerialPort.VControls.Throttle;
+				}
+				break;
+			default:
+				break;
+			}
 
-            if (SettingsNStuff.ThrottleEnable)
-                s.mainThrottle = KSPSerialPort.VControls.Throttle;
+			switch (SettingsNStuff.PitchEnable)
+			{
+			case SettingsNStuff.ControlType.ExternalTotal:
+				s.pitch = KSPSerialPort.VControls.Pitch;
+				break;
+			case SettingsNStuff.ControlType.InternalPriority:
+				if (s.pitch == 0)
+					s.pitch = KSPSerialPort.VControls.Pitch;
+				break;
+			case SettingsNStuff.ControlType.ExternalPriority:
+				if (KSPSerialPort.VControls.Pitch != 0)
+					s.pitch = KSPSerialPort.VControls.Pitch;
+				break;
+			default:
+				break;
+			}
 
-            if (SettingsNStuff.PitchEnable)
-                s.pitch = KSPSerialPort.VControls.Pitch;
+			switch (SettingsNStuff.RollEnable)
+			{
+			case SettingsNStuff.ControlType.ExternalTotal:
+				s.roll = KSPSerialPort.VControls.Roll;
+				break;
+			case SettingsNStuff.ControlType.InternalPriority:
+				if (s.roll == 0)
+					s.roll = KSPSerialPort.VControls.Roll;
+				break;
+			case SettingsNStuff.ControlType.ExternalPriority:
+				if (KSPSerialPort.VControls.Roll != 0)
+					s.roll = KSPSerialPort.VControls.Roll;
+				break;
+			default:
+				break;
+			}
 
-            if (SettingsNStuff.RollEnable)
-                s.roll = KSPSerialPort.VControls.Roll;
+			switch (SettingsNStuff.YawEnable)
+			{
+			case SettingsNStuff.ControlType.ExternalTotal:
+				s.yaw = KSPSerialPort.VControls.Yaw;
+				break;
+			case SettingsNStuff.ControlType.InternalPriority:
+				if (s.yaw == 0)
+					s.yaw = KSPSerialPort.VControls.Yaw;
+				break;
+			case SettingsNStuff.ControlType.ExternalPriority:
+				if (KSPSerialPort.VControls.Yaw != 0)
+					s.yaw = KSPSerialPort.VControls.Yaw;
+				break;
+			default:
+				break;
+			}
 
-            if (SettingsNStuff.YawEnable)
-                s.yaw = KSPSerialPort.VControls.Yaw;
+			switch (SettingsNStuff.TXEnable)
+			{
+			case SettingsNStuff.ControlType.ExternalTotal:
+				s.X = KSPSerialPort.VControls.TX;
+				break;
+			case SettingsNStuff.ControlType.InternalPriority:
+				if (s.X == 0)
+					s.X = KSPSerialPort.VControls.TX;
+				break;
+			case SettingsNStuff.ControlType.ExternalPriority:
+				if (KSPSerialPort.VControls.TX != 0)
+					s.X = KSPSerialPort.VControls.TX;
+				break;
+			default:
+				break;
+			}
 
-            if (SettingsNStuff.TXEnable)
-                s.X = KSPSerialPort.VControls.TX;
+			switch (SettingsNStuff.TYEnable)
+			{
+			case SettingsNStuff.ControlType.ExternalTotal:
+				s.Y = KSPSerialPort.VControls.TY;
+				break;
+			case SettingsNStuff.ControlType.InternalPriority:
+				if (s.Y == 0)
+					s.Y = KSPSerialPort.VControls.TY;
+				break;
+			case SettingsNStuff.ControlType.ExternalPriority:
+				if (KSPSerialPort.VControls.TY != 0)
+					s.Y = KSPSerialPort.VControls.TY;
+				break;
+			default:
+				break;
+			}
 
-            if (SettingsNStuff.TYEnable)
-                s.Y = KSPSerialPort.VControls.TY;
-
-            if (SettingsNStuff.TZEnable)
-                s.Z = KSPSerialPort.VControls.TZ;
+			switch (SettingsNStuff.TZEnable)
+			{
+			case SettingsNStuff.ControlType.ExternalTotal:
+				s.Z = KSPSerialPort.VControls.TZ;
+				break;
+			case SettingsNStuff.ControlType.InternalPriority:
+				if (s.Z == 0)
+					s.Z = KSPSerialPort.VControls.TZ;
+				break;
+			case SettingsNStuff.ControlType.ExternalPriority:
+				if (KSPSerialPort.VControls.TZ != 0)
+					s.Z = KSPSerialPort.VControls.TZ;
+				break;
+			default:
+				break;
+			}
 
         }
 

--- a/KSPSerialIO/KSPIO.cs
+++ b/KSPSerialIO/KSPIO.cs
@@ -320,7 +320,7 @@ namespace KSPSerialIO
                 try
                 {
                     //Use registry hack to get a list of serial ports until we get system.io.ports
-                    RegistryKey SerialCOMSKey = Registry.LocalMachine.OpenSubKey(@"HARDWARE\DEVICEMAP\SERIALCOMM\");
+                    RegistryKey SerialCOMSKey = Registry.LocalMachine.OpenSubKey(@"HARDWARE\\DEVICEMAP\\SERIALCOMM\\");
 
                     Begin();
 

--- a/KSPSerialIO/KSPIO.cs
+++ b/KSPSerialIO/KSPIO.cs
@@ -123,25 +123,24 @@ namespace KSPSerialIO
     [KSPAddon(KSPAddon.Startup.MainMenu, false)]
     public class SettingsNStuff : MonoBehaviour
     {
-		public enum ControlType {
-			InternalTotal = 0, // Always use value provided by KSP.
-			ExternalTotal = 1, // Always use value from serial packet, overriding internal value.
-			InternalPriority = 2, // Only use external value if internal is 0.
-			ExternalPriority = 3, // Only use internal value if external is 0.
-		}
 
         public static PluginConfiguration cfg = PluginConfiguration.CreateForType<SettingsNStuff>();
         public static string DefaultPort;
         public static double refreshrate;
         public static int HandshakeDelay;
         public static int BaudRate;
-		public static ControlType ThrottleEnable;
-		public static ControlType PitchEnable;
-		public static ControlType RollEnable;
-		public static ControlType YawEnable;
-		public static ControlType TXEnable;
-		public static ControlType TYEnable;
-		public static ControlType TZEnable;
+		// Throttle and axis controls have the following settings:
+		// 0: The internal value (supplied by KSP) is always used.
+		// 1: The external value (read from serial packet) is always used.
+		// 2: If the internal value is not zero use it, otherwise use the external value.
+		// 3: If the external value is not zero use it, otherwise use the internal value.
+		public static int ThrottleEnable;
+		public static int PitchEnable;
+		public static int RollEnable;
+		public static int YawEnable;
+		public static int TXEnable;
+		public static int TYEnable;
+		public static int TZEnable;
         public static double SASTol;
 
         void Awake()
@@ -164,25 +163,25 @@ namespace KSPSerialIO
             HandshakeDelay = cfg.GetValue<int>("HandshakeDelay");
             print("KSPSerialIO: Handshake Delay = " + HandshakeDelay.ToString());
 
-			ThrottleEnable = cfg.GetValue<SettingsNStuff.ControlType>("ThrottleEnable");
+			ThrottleEnable = cfg.GetValue<int>("ThrottleEnable");
             print("KSPSerialIO: Throttle Enable = " + ThrottleEnable.ToString());
 
-			PitchEnable = cfg.GetValue<SettingsNStuff.ControlType>("PitchEnable");
+			PitchEnable = cfg.GetValue<int>("PitchEnable");
             print("KSPSerialIO: Pitch Enable = " + PitchEnable.ToString());
 
-			RollEnable = cfg.GetValue<SettingsNStuff.ControlType>("RollEnable");
+			RollEnable = cfg.GetValue<int>("RollEnable");
             print("KSPSerialIO: Roll Enable = " + RollEnable.ToString());
 
-			YawEnable = cfg.GetValue<SettingsNStuff.ControlType>("YawEnable");
+			YawEnable = cfg.GetValue<int>("YawEnable");
             print("KSPSerialIO: Yaw Enable = " + YawEnable.ToString());
 
-			TXEnable = cfg.GetValue<SettingsNStuff.ControlType>("TXEnable");
+			TXEnable = cfg.GetValue<int>("TXEnable");
             print("KSPSerialIO: Translate X Enable = " + TXEnable.ToString());
 
-			TYEnable = cfg.GetValue<SettingsNStuff.ControlType>("TYEnable");
+			TYEnable = cfg.GetValue<int>("TYEnable");
             print("KSPSerialIO: Translate Y Enable = " + TYEnable.ToString());
 
-			TZEnable = cfg.GetValue<SettingsNStuff.ControlType>("TZEnable");
+			TZEnable = cfg.GetValue<int>("TZEnable");
             print("KSPSerialIO: Translate Z Enable = " + TZEnable.ToString());
 
             SASTol = cfg.GetValue<double>("SASTol");
@@ -1020,16 +1019,16 @@ namespace KSPSerialIO
         {
 			switch (SettingsNStuff.ThrottleEnable)
 			{
-			case SettingsNStuff.ControlType.ExternalTotal:
+			case 1:
 				s.mainThrottle = KSPSerialPort.VControls.Throttle;
 				break;
-			case SettingsNStuff.ControlType.InternalPriority:
+			case 2:
 				if (s.mainThrottle == 0)
 				{
 					s.mainThrottle = KSPSerialPort.VControls.Throttle;
 				}
 				break;
-			case SettingsNStuff.ControlType.ExternalPriority:
+			case 3:
 				if (KSPSerialPort.VControls.Throttle != 0)
 				{
 					s.mainThrottle = KSPSerialPort.VControls.Throttle;
@@ -1041,14 +1040,14 @@ namespace KSPSerialIO
 
 			switch (SettingsNStuff.PitchEnable)
 			{
-			case SettingsNStuff.ControlType.ExternalTotal:
+			case 1:
 				s.pitch = KSPSerialPort.VControls.Pitch;
 				break;
-			case SettingsNStuff.ControlType.InternalPriority:
+			case 2:
 				if (s.pitch == 0)
 					s.pitch = KSPSerialPort.VControls.Pitch;
 				break;
-			case SettingsNStuff.ControlType.ExternalPriority:
+			case 3:
 				if (KSPSerialPort.VControls.Pitch != 0)
 					s.pitch = KSPSerialPort.VControls.Pitch;
 				break;
@@ -1058,14 +1057,14 @@ namespace KSPSerialIO
 
 			switch (SettingsNStuff.RollEnable)
 			{
-			case SettingsNStuff.ControlType.ExternalTotal:
+			case 1:
 				s.roll = KSPSerialPort.VControls.Roll;
 				break;
-			case SettingsNStuff.ControlType.InternalPriority:
+			case 2:
 				if (s.roll == 0)
 					s.roll = KSPSerialPort.VControls.Roll;
 				break;
-			case SettingsNStuff.ControlType.ExternalPriority:
+			case 3:
 				if (KSPSerialPort.VControls.Roll != 0)
 					s.roll = KSPSerialPort.VControls.Roll;
 				break;
@@ -1075,14 +1074,14 @@ namespace KSPSerialIO
 
 			switch (SettingsNStuff.YawEnable)
 			{
-			case SettingsNStuff.ControlType.ExternalTotal:
+			case 1:
 				s.yaw = KSPSerialPort.VControls.Yaw;
 				break;
-			case SettingsNStuff.ControlType.InternalPriority:
+			case 2:
 				if (s.yaw == 0)
 					s.yaw = KSPSerialPort.VControls.Yaw;
 				break;
-			case SettingsNStuff.ControlType.ExternalPriority:
+			case 3:
 				if (KSPSerialPort.VControls.Yaw != 0)
 					s.yaw = KSPSerialPort.VControls.Yaw;
 				break;
@@ -1092,14 +1091,14 @@ namespace KSPSerialIO
 
 			switch (SettingsNStuff.TXEnable)
 			{
-			case SettingsNStuff.ControlType.ExternalTotal:
+			case 1:
 				s.X = KSPSerialPort.VControls.TX;
 				break;
-			case SettingsNStuff.ControlType.InternalPriority:
+			case 2:
 				if (s.X == 0)
 					s.X = KSPSerialPort.VControls.TX;
 				break;
-			case SettingsNStuff.ControlType.ExternalPriority:
+			case 3:
 				if (KSPSerialPort.VControls.TX != 0)
 					s.X = KSPSerialPort.VControls.TX;
 				break;
@@ -1109,14 +1108,14 @@ namespace KSPSerialIO
 
 			switch (SettingsNStuff.TYEnable)
 			{
-			case SettingsNStuff.ControlType.ExternalTotal:
+			case 1:
 				s.Y = KSPSerialPort.VControls.TY;
 				break;
-			case SettingsNStuff.ControlType.InternalPriority:
+			case 2:
 				if (s.Y == 0)
 					s.Y = KSPSerialPort.VControls.TY;
 				break;
-			case SettingsNStuff.ControlType.ExternalPriority:
+			case 3:
 				if (KSPSerialPort.VControls.TY != 0)
 					s.Y = KSPSerialPort.VControls.TY;
 				break;
@@ -1126,14 +1125,14 @@ namespace KSPSerialIO
 
 			switch (SettingsNStuff.TZEnable)
 			{
-			case SettingsNStuff.ControlType.ExternalTotal:
+			case 1:
 				s.Z = KSPSerialPort.VControls.TZ;
 				break;
-			case SettingsNStuff.ControlType.InternalPriority:
+			case 2:
 				if (s.Z == 0)
 					s.Z = KSPSerialPort.VControls.TZ;
 				break;
-			case SettingsNStuff.ControlType.ExternalPriority:
+			case 3:
 				if (KSPSerialPort.VControls.TZ != 0)
 					s.Z = KSPSerialPort.VControls.TZ;
 				break;

--- a/KSPSerialIO/KSPIO.cs
+++ b/KSPSerialIO/KSPIO.cs
@@ -129,18 +129,18 @@ namespace KSPSerialIO
         public static double refreshrate;
         public static int HandshakeDelay;
         public static int BaudRate;
-		// Throttle and axis controls have the following settings:
-		// 0: The internal value (supplied by KSP) is always used.
-		// 1: The external value (read from serial packet) is always used.
-		// 2: If the internal value is not zero use it, otherwise use the external value.
-		// 3: If the external value is not zero use it, otherwise use the internal value.
-		public static int ThrottleEnable;
-		public static int PitchEnable;
-		public static int RollEnable;
-		public static int YawEnable;
-		public static int TXEnable;
-		public static int TYEnable;
-		public static int TZEnable;
+        // Throttle and axis controls have the following settings:
+        // 0: The internal value (supplied by KSP) is always used.
+        // 1: The external value (read from serial packet) is always used.
+        // 2: If the internal value is not zero use it, otherwise use the external value.
+        // 3: If the external value is not zero use it, otherwise use the internal value.
+        public static int ThrottleEnable;
+        public static int PitchEnable;
+        public static int RollEnable;
+        public static int YawEnable;
+        public static int TXEnable;
+        public static int TYEnable;
+        public static int TZEnable;
         public static double SASTol;
 
         void Awake()
@@ -163,25 +163,25 @@ namespace KSPSerialIO
             HandshakeDelay = cfg.GetValue<int>("HandshakeDelay");
             print("KSPSerialIO: Handshake Delay = " + HandshakeDelay.ToString());
 
-			ThrottleEnable = cfg.GetValue<int>("ThrottleEnable");
+            ThrottleEnable = cfg.GetValue<int>("ThrottleEnable");
             print("KSPSerialIO: Throttle Enable = " + ThrottleEnable.ToString());
 
-			PitchEnable = cfg.GetValue<int>("PitchEnable");
+            PitchEnable = cfg.GetValue<int>("PitchEnable");
             print("KSPSerialIO: Pitch Enable = " + PitchEnable.ToString());
 
-			RollEnable = cfg.GetValue<int>("RollEnable");
+            RollEnable = cfg.GetValue<int>("RollEnable");
             print("KSPSerialIO: Roll Enable = " + RollEnable.ToString());
 
-			YawEnable = cfg.GetValue<int>("YawEnable");
+            YawEnable = cfg.GetValue<int>("YawEnable");
             print("KSPSerialIO: Yaw Enable = " + YawEnable.ToString());
 
-			TXEnable = cfg.GetValue<int>("TXEnable");
+            TXEnable = cfg.GetValue<int>("TXEnable");
             print("KSPSerialIO: Translate X Enable = " + TXEnable.ToString());
 
-			TYEnable = cfg.GetValue<int>("TYEnable");
+            TYEnable = cfg.GetValue<int>("TYEnable");
             print("KSPSerialIO: Translate Y Enable = " + TYEnable.ToString());
 
-			TZEnable = cfg.GetValue<int>("TZEnable");
+            TZEnable = cfg.GetValue<int>("TZEnable");
             print("KSPSerialIO: Translate Z Enable = " + TZEnable.ToString());
 
             SASTol = cfg.GetValue<double>("SASTol");
@@ -275,16 +275,16 @@ namespace KSPSerialIO
             return obj;
         }
         /*
-        private static T ReadUsingMarshalUnsafe<T>(byte[] data) where T : struct
-        {
-            unsafe
-            {
-                fixed (byte* p = &data[0])
-                {
-                    return (T)Marshal.PtrToStructure(new IntPtr(p), typeof(T));
-                }
-            }
-        }
+          private static T ReadUsingMarshalUnsafe<T>(byte[] data) where T : struct
+          {
+          unsafe
+          {
+          fixed (byte* p = &data[0])
+          {
+          return (T)Marshal.PtrToStructure(new IntPtr(p), typeof(T));
+          }
+          }
+          }
         */
         void initializeDataPackets()
         {


### PR DESCRIPTION
Adds configuration options to throttle, translation and rotation controls allowing various combinations of control by serial device and by the usual KSP internal mechanism. These controls are now configured by ints rather than bools, with the following possible settings:

* KSPSerial Control is disabled. Identical to the old boolean off option.
* KSPSerial Control is enabled and total. Identical to the old boolean on option.
* Control can be set by both KSPSerial and KSP internal, but priority is given to the internal setting. KSPSerial will only overwrite a control if internal is setting it to 0.
* As above, but priority is given to KSPSerial over KSP internal. The internal setting will only be used if KSPSerial is setting the control to 0.
