### PR TITLE
Add orbital vectors to data packet

### DIFF
--- a/KSPSerialIO/KSPIO.cs
+++ b/KSPSerialIO/KSPIO.cs
@@ -1597,34 +1597,6 @@ namespace KSPSerialIO
         {
             return new Vector3d(v.x, v.z, v.y);
         }
-
-        private Orbit fetchFarOrbit(Vessel v)
-        {
-            Orbit prevOrbit = null;
-            Orbit curOrbit = v.orbit;
-            Orbit nextOrbit = curOrbit.nextPatch;
-            while (nextOrbit != null && nextOrbit.activePatch)
-            {
-                //if (prevOrbit != null && prevOrbit.referenceBody.name.Equals(nextOrbit.referenceBody.name, StringComparison.Ordinal))
-                if (prevOrbit != null && ReferenceEquals(prevOrbit.referenceBody, nextOrbit.referenceBody))
-                {
-                    break;
-                } else
-                {
-                    prevOrbit = curOrbit;
-                    curOrbit = nextOrbit;
-                    nextOrbit = curOrbit.nextPatch;
-                }
-            }
-
-            if (prevOrbit == null)
-            {
-                return null;
-            } else
-            {
-                return curOrbit;
-            }
-        }
         #endregion
 
         void FixedUpdate()

--- a/KSPSerialIO/KSPIO.cs
+++ b/KSPSerialIO/KSPIO.cs
@@ -69,6 +69,18 @@ namespace KSPSerialIO
         public float IAS;           //50  Indicated Air Speed
         public byte CurrentStage;   //51  Current stage number
         public byte TotalStage;     //52  TotalNumber of stages
+        public float ProgradePitch; //53 Direction of orbital prograde,
+        public float ProgradeHeading;//54 relative to vessel attitude
+        public float NormalPitch;   //55 Direction of orbit normal,
+        public float NormalHeading; //56 relative to vessel attitude
+        public float RadialPitch;   //57 Direction of orbit radial,
+        public float RadialHeading; //58 relative to vessel attitude
+        public float ProgradeSPitch; //59 Direction of surface prograde,
+        public float ProgradeSHeading;//60 relative to vessel attitude
+        public float TargetPitch; //61 Direction of target prograde
+        public float TargetHeading; //62 relative to vessel attitude
+        public float ManeuverPitch; //63 Direction of maneuver
+        public float ManeuverHeading; //64 relative to vessel attitude
     }
 
     [StructLayout(LayoutKind.Sequential, Pack = 1)]

--- a/KSPSerialIO/KSPIO.cs
+++ b/KSPSerialIO/KSPIO.cs
@@ -864,9 +864,8 @@ namespace KSPSerialIO
                         }
                     }
 
-                    Vessel targetVessel = FlightGlobals.fetch.VesselTarget.GetVessel();
-                    if (targetVessel != null)
-                    {
+                    if (FlightGlobals.fetch.VesselTarget != null) {
+                        Vessel targetVessel = FlightGlobals.fetch.VesselTarget.GetVessel();
                         Vector3 targetVector = (targetVessel.GetWorldPos3D() - ActiveVessel.GetWorldPos3D()).normalized;
                         double[] targetRelativeHeading = getOffsetFromHeading(ActiveVessel, targetVector);
                         KSPSerialPort.VData.TargetPitch = (float)targetRelativeHeading[0];

--- a/KSPSerialIO/KSPIO.cs
+++ b/KSPSerialIO/KSPIO.cs
@@ -1426,7 +1426,7 @@ namespace KSPSerialIO
         {
             if (x < 0)
             {
-                x = 360 - x;
+                x = x + 360;
             }
             else if (x > 360)
             {

--- a/KSPSerialIO/KSPIO.cs
+++ b/KSPSerialIO/KSPIO.cs
@@ -62,25 +62,25 @@ namespace KSPSerialIO
         public float Pitch;         //43
         public float Roll;          //44
         public float Heading;       //45
-        public UInt16 ActionGroups; //46  status bit order:SAS, RCS, Light, Gear, Brakes, Abort, Custom01 - 10 
-        public byte SOINumber;      //47  SOI Number (decimal format: sun-planet-moon e.g. 130 = kerbin, 131 = mun)
-        public byte MaxOverHeat;    //48  Max part overheat (% percent)
-        public float MachNumber;    //49
-        public float IAS;           //50  Indicated Air Speed
-        public byte CurrentStage;   //51  Current stage number
-        public byte TotalStage;     //52  TotalNumber of stages
-        public float ProgradePitch; //53 Direction of orbital prograde,
-        public float ProgradeHeading;//54 relative to vessel attitude
-        public float NormalPitch;   //55 Direction of orbit normal,
-        public float NormalHeading; //56 relative to vessel attitude
-        public float RadialPitch;   //57 Direction of orbit radial,
-        public float RadialHeading; //58 relative to vessel attitude
-        public float ProgradeSPitch; //59 Direction of surface prograde,
-        public float ProgradeSHeading;//60 relative to vessel attitude
-        public float TargetPitch; //61 Direction of target prograde
-        public float TargetHeading; //62 relative to vessel attitude
-        public float ManeuverPitch; //63 Direction of maneuver
-        public float ManeuverHeading; //64 relative to vessel attitude
+        public float ProgradePitch; //46 Direction of orbital prograde,
+        public float ProgradeHeading;//47 relative to vessel attitude
+        public float NormalPitch;   //48 Direction of orbit normal,
+        public float NormalHeading; //49 relative to vessel attitude
+        public float RadialPitch;   //50 Direction of orbit radial,
+        public float RadialHeading; //51 relative to vessel attitude
+        public float ProgradeSPitch; //52 Direction of surface prograde,
+        public float ProgradeSHeading;//53 relative to vessel attitude
+        public float TargetPitch; //54 Direction of target prograde
+        public float TargetHeading; //55 relative to vessel attitude
+        public float ManeuverPitch; //56 Direction of maneuver
+        public float ManeuverHeading; //57 relative to vessel attitude
+        public UInt16 ActionGroups; //58  status bit order:SAS, RCS, Light, Gear, Brakes, Abort, Custom01 - 10 
+        public byte SOINumber;      //59  SOI Number (decimal format: sun-planet-moon e.g. 130 = kerbin, 131 = mun)
+        public byte MaxOverHeat;    //60  Max part overheat (% percent)
+        public float MachNumber;    //61
+        public float IAS;           //62  Indicated Air Speed
+        public byte CurrentStage;   //63  Current stage number
+        public byte TotalStage;     //64  TotalNumber of stages
     }
 
     [StructLayout(LayoutKind.Sequential, Pack = 1)]

--- a/KSPSerialIO/KSPIO.cs
+++ b/KSPSerialIO/KSPIO.cs
@@ -858,7 +858,7 @@ namespace KSPSerialIO
 
                                 Vector3 maneuverVector = ActiveVessel.patchedConicSolver.maneuverNodes[0].GetBurnVector(ActiveVessel.orbit).normalized;
                                 double[] maneuverRelativeHeading = getOffsetFromHeading(ActiveVessel, maneuverVector);
-                                KSPSerialPort.VData.ManeuverPitch = ToScaledUInt(maneuverRelativeHeading[0]+180);
+                                KSPSerialPort.VData.ManeuverPitch = ToScaledUInt(maneuverRelativeHeading[0]);
                                 KSPSerialPort.VData.ManeuverHeading = ToScaledUInt(maneuverRelativeHeading[1]);
                             }
                         }
@@ -868,15 +868,15 @@ namespace KSPSerialIO
                         Vessel targetVessel = FlightGlobals.fetch.VesselTarget.GetVessel();
                         Vector3 targetVector = (targetVessel.GetWorldPos3D() - ActiveVessel.GetWorldPos3D()).normalized;
                         double[] targetRelativeHeading = getOffsetFromHeading(ActiveVessel, targetVector);
-                        KSPSerialPort.VData.TargetPitch = ToScaledUInt(targetRelativeHeading[0]+180);
+                        KSPSerialPort.VData.TargetPitch = ToScaledUInt(targetRelativeHeading[0]);
                         KSPSerialPort.VData.TargetHeading = ToScaledUInt(targetRelativeHeading[1]);
                     }
 
                     //Debug.Log("KSPSerialIO: 5");
                     Quaternion attitude = updateHeadingPitchRollField(ActiveVessel);
 
-                    KSPSerialPort.VData.Roll = ToScaledUInt(((attitude.eulerAngles.z > 180) ? (attitude.eulerAngles.z - 360.0) : attitude.eulerAngles.z)+180);
-                    KSPSerialPort.VData.Pitch = ToScaledUInt(((attitude.eulerAngles.x > 180) ? (360.0 - attitude.eulerAngles.x) : -attitude.eulerAngles.x)+180);
+                    KSPSerialPort.VData.Roll = ToScaledUInt(((attitude.eulerAngles.z > 180) ? (attitude.eulerAngles.z - 360.0) : attitude.eulerAngles.z));
+                    KSPSerialPort.VData.Pitch = ToScaledUInt(((attitude.eulerAngles.x > 180) ? (360.0 - attitude.eulerAngles.x) : -attitude.eulerAngles.x));
                     KSPSerialPort.VData.Heading = ToScaledUInt(attitude.eulerAngles.y);
 
                     Vector3 progradeVector = ActiveVessel.GetObtVelocity().normalized;
@@ -887,13 +887,13 @@ namespace KSPSerialIO
                     double[] normalHeading = getOffsetFromHeading(ActiveVessel, normalVector);
                     double[] radialHeading = getOffsetFromHeading(ActiveVessel, radialVector);
                     double[] progradeSHeading = getOffsetFromHeading(ActiveVessel, progradeSVector);
-                    KSPSerialPort.VData.ProgradePitch = ToScaledUInt(progradeHeading[0]+180);
+                    KSPSerialPort.VData.ProgradePitch = ToScaledUInt(progradeHeading[0]);
                     KSPSerialPort.VData.ProgradeHeading = ToScaledUInt(progradeHeading[1]);
-                    KSPSerialPort.VData.NormalPitch = ToScaledUInt(normalHeading[0]+180);
+                    KSPSerialPort.VData.NormalPitch = ToScaledUInt(normalHeading[0]);
                     KSPSerialPort.VData.NormalHeading = ToScaledUInt(normalHeading[1]);
-                    KSPSerialPort.VData.RadialPitch = ToScaledUInt(radialHeading[0]+180);
+                    KSPSerialPort.VData.RadialPitch = ToScaledUInt(radialHeading[0]);
                     KSPSerialPort.VData.RadialHeading = ToScaledUInt(radialHeading[1]);
-                    KSPSerialPort.VData.ProgradeSPitch = ToScaledUInt(progradeSHeading[0]+180);
+                    KSPSerialPort.VData.ProgradeSPitch = ToScaledUInt(progradeSHeading[0]);
                     KSPSerialPort.VData.ProgradeSHeading = ToScaledUInt(progradeSHeading[1]);
 
                     KSPSerialPort.ControlStatus((int)enumAG.SAS, ActiveVessel.ActionGroups[KSPActionGroup.SAS]);
@@ -1424,6 +1424,14 @@ namespace KSPSerialIO
 
         private UInt16 ToScaledUInt(double x)
         {
+            if (x < 0)
+            {
+                x = 360 - x;
+            }
+            else if (x > 360)
+            {
+                x = x % 360;
+            }
             UInt16 result;
             result = (UInt16)(x * 65535 / 360);
             return result;

--- a/KSPSerialIO/KSPIO.cs
+++ b/KSPSerialIO/KSPIO.cs
@@ -59,21 +59,21 @@ namespace KSPSerialIO
         public float VOrbit;        //40
         public UInt32 MNTime;       //41
         public float MNDeltaV;      //42
-        public float Pitch;         //43
-        public float Roll;          //44
-        public float Heading;       //45
-        public float ProgradePitch; //46 Direction of orbital prograde,
-        public float ProgradeHeading;//47 relative to vessel attitude
-        public float NormalPitch;   //48 Direction of orbit normal,
-        public float NormalHeading; //49 relative to vessel attitude
-        public float RadialPitch;   //50 Direction of orbit radial,
-        public float RadialHeading; //51 relative to vessel attitude
-        public float ProgradeSPitch; //52 Direction of surface prograde,
-        public float ProgradeSHeading;//53 relative to vessel attitude
-        public float TargetPitch; //54 Direction of target prograde
-        public float TargetHeading; //55 relative to vessel attitude
-        public float ManeuverPitch; //56 Direction of maneuver
-        public float ManeuverHeading; //57 relative to vessel attitude
+        public Int16 Pitch;         //43 All pitch roll and heading info is sent as 10.6 fixed point numbers
+        public Int16 Roll;          //44
+        public Int16 Heading;       //45
+        public Int16 ProgradePitch; //46 Direction of orbital prograde,
+        public Int16 ProgradeHeading;//47 relative to vessel attitude
+        public Int16 NormalPitch;   //48 Direction of orbit normal,
+        public Int16 NormalHeading; //49 relative to vessel attitude
+        public Int16 RadialPitch;   //50 Direction of orbit radial,
+        public Int16 RadialHeading; //51 relative to vessel attitude
+        public Int16 ProgradeSPitch; //52 Direction of surface prograde,
+        public Int16 ProgradeSHeading;//53 relative to vessel attitude
+        public Int16 TargetPitch; //54 Direction of target prograde
+        public Int16 TargetHeading; //55 relative to vessel attitude
+        public Int16 ManeuverPitch; //56 Direction of maneuver
+        public Int16 ManeuverHeading; //57 relative to vessel attitude
         public UInt16 ActionGroups; //58  status bit order:SAS, RCS, Light, Gear, Brakes, Abort, Custom01 - 10 
         public byte SOINumber;      //59  SOI Number (decimal format: sun-planet-moon e.g. 130 = kerbin, 131 = mun)
         public byte MaxOverHeat;    //60  Max part overheat (% percent)
@@ -858,8 +858,8 @@ namespace KSPSerialIO
 
                                 Vector3 maneuverVector = ActiveVessel.patchedConicSolver.maneuverNodes[0].GetBurnVector(ActiveVessel.orbit).normalized;
                                 double[] maneuverRelativeHeading = getOffsetFromHeading(ActiveVessel, maneuverVector);
-                                KSPSerialPort.VData.ManeuverPitch = (float)maneuverRelativeHeading[0];
-                                KSPSerialPort.VData.ManeuverHeading = (float)maneuverRelativeHeading[1];
+                                KSPSerialPort.VData.ManeuverPitch = ToFixedPoint(maneuverRelativeHeading[0]);
+                                KSPSerialPort.VData.ManeuverHeading = ToFixedPoint(maneuverRelativeHeading[1]);
                             }
                         }
                     }
@@ -868,16 +868,16 @@ namespace KSPSerialIO
                         Vessel targetVessel = FlightGlobals.fetch.VesselTarget.GetVessel();
                         Vector3 targetVector = (targetVessel.GetWorldPos3D() - ActiveVessel.GetWorldPos3D()).normalized;
                         double[] targetRelativeHeading = getOffsetFromHeading(ActiveVessel, targetVector);
-                        KSPSerialPort.VData.TargetPitch = (float)targetRelativeHeading[0];
-                        KSPSerialPort.VData.TargetHeading = (float)targetRelativeHeading[1];
+                        KSPSerialPort.VData.TargetPitch = ToFixedPoint(targetRelativeHeading[0]);
+                        KSPSerialPort.VData.TargetHeading = ToFixedPoint(targetRelativeHeading[1]);
                     }
 
                     //Debug.Log("KSPSerialIO: 5");
                     Quaternion attitude = updateHeadingPitchRollField(ActiveVessel);
 
-                    KSPSerialPort.VData.Roll = (float)((attitude.eulerAngles.z > 180) ? (attitude.eulerAngles.z - 360.0) : attitude.eulerAngles.z);
-                    KSPSerialPort.VData.Pitch = (float)((attitude.eulerAngles.x > 180) ? (360.0 - attitude.eulerAngles.x) : -attitude.eulerAngles.x);
-                    KSPSerialPort.VData.Heading = (float)attitude.eulerAngles.y;
+                    KSPSerialPort.VData.Roll = ToFixedPoint(((attitude.eulerAngles.z > 180) ? (attitude.eulerAngles.z - 360.0) : attitude.eulerAngles.z));
+                    KSPSerialPort.VData.Pitch = ToFixedPoint(((attitude.eulerAngles.x > 180) ? (360.0 - attitude.eulerAngles.x) : -attitude.eulerAngles.x));
+                    KSPSerialPort.VData.Heading = ToFixedPoint(attitude.eulerAngles.y);
 
                     Vector3 progradeVector = ActiveVessel.GetObtVelocity().normalized;
                     Vector3 normalVector = swapYZ(ActiveVessel.GetOrbit().GetOrbitNormal()).normalized;
@@ -887,14 +887,14 @@ namespace KSPSerialIO
                     double[] normalHeading = getOffsetFromHeading(ActiveVessel, normalVector);
                     double[] radialHeading = getOffsetFromHeading(ActiveVessel, radialVector);
                     double[] progradeSHeading = getOffsetFromHeading(ActiveVessel, progradeSVector);
-                    KSPSerialPort.VData.ProgradePitch = (float)progradeHeading[0];
-                    KSPSerialPort.VData.ProgradeHeading = (float)progradeHeading[1];
-                    KSPSerialPort.VData.NormalPitch = (float)normalHeading[0];
-                    KSPSerialPort.VData.NormalHeading = (float)normalHeading[1];
-                    KSPSerialPort.VData.RadialPitch = (float)radialHeading[0];
-                    KSPSerialPort.VData.RadialHeading = (float)radialHeading[1];
-                    KSPSerialPort.VData.ProgradeSPitch = (float)progradeSHeading[0];
-                    KSPSerialPort.VData.ProgradeSHeading = (float)progradeSHeading[1];
+                    KSPSerialPort.VData.ProgradePitch = ToFixedPoint(progradeHeading[0]);
+                    KSPSerialPort.VData.ProgradeHeading = ToFixedPoint(progradeHeading[1]);
+                    KSPSerialPort.VData.NormalPitch = ToFixedPoint(normalHeading[0]);
+                    KSPSerialPort.VData.NormalHeading = ToFixedPoint(normalHeading[1]);
+                    KSPSerialPort.VData.RadialPitch = ToFixedPoint(radialHeading[0]);
+                    KSPSerialPort.VData.RadialHeading = ToFixedPoint(radialHeading[1]);
+                    KSPSerialPort.VData.ProgradeSPitch = ToFixedPoint(progradeSHeading[0]);
+                    KSPSerialPort.VData.ProgradeSHeading = ToFixedPoint(progradeSHeading[1]);
 
                     KSPSerialPort.ControlStatus((int)enumAG.SAS, ActiveVessel.ActionGroups[KSPActionGroup.SAS]);
                     KSPSerialPort.ControlStatus((int)enumAG.RCS, ActiveVessel.ActionGroups[KSPActionGroup.RCS]);
@@ -1420,6 +1420,11 @@ namespace KSPSerialIO
                     break;
             }
             return SOI;
+        }
+
+        private Int16 ToFixedPoint(double x)
+        {
+            return (Int16)(x * (1 << 6));
         }
 
         // this recursive stage look up stuff stolen and modified from KOS and others

--- a/KSPSerialIO/KSPIO.cs
+++ b/KSPSerialIO/KSPIO.cs
@@ -59,21 +59,21 @@ namespace KSPSerialIO
         public float VOrbit;        //40
         public UInt32 MNTime;       //41
         public float MNDeltaV;      //42
-        public Int16 Pitch;         //43 All pitch roll and heading info is sent as 10.6 fixed point numbers
-        public Int16 Roll;          //44
-        public Int16 Heading;       //45
-        public Int16 ProgradePitch; //46 Direction of orbital prograde,
-        public Int16 ProgradeHeading;//47 relative to vessel attitude
-        public Int16 NormalPitch;   //48 Direction of orbit normal,
-        public Int16 NormalHeading; //49 relative to vessel attitude
-        public Int16 RadialPitch;   //50 Direction of orbit radial,
-        public Int16 RadialHeading; //51 relative to vessel attitude
-        public Int16 ProgradeSPitch; //52 Direction of surface prograde,
-        public Int16 ProgradeSHeading;//53 relative to vessel attitude
-        public Int16 TargetPitch; //54 Direction of target prograde
-        public Int16 TargetHeading; //55 relative to vessel attitude
-        public Int16 ManeuverPitch; //56 Direction of maneuver
-        public Int16 ManeuverHeading; //57 relative to vessel attitude
+        public UInt16 Pitch;         //43
+        public UInt16 Roll;          //44
+        public UInt16 Heading;       //45 Heading is always 0-360. Pitch and Roll -180 to 180.
+        public UInt16 ProgradePitch; //46 Direction of orbital prograde,
+        public UInt16 ProgradeHeading;//47 relative to vessel attitude
+        public UInt16 NormalPitch;   //48 Direction of orbit normal,
+        public UInt16 NormalHeading; //49 relative to vessel attitude
+        public UInt16 RadialPitch;   //50 Direction of orbit radial,
+        public UInt16 RadialHeading; //51 relative to vessel attitude
+        public UInt16 ProgradeSPitch; //52 Direction of surface prograde,
+        public UInt16 ProgradeSHeading;//53 relative to vessel attitude
+        public UInt16 TargetPitch; //54 Direction of target prograde
+        public UInt16 TargetHeading; //55 relative to vessel attitude
+        public UInt16 ManeuverPitch; //56 Direction of maneuver
+        public UInt16 ManeuverHeading; //57 relative to vessel attitude
         public UInt16 ActionGroups; //58  status bit order:SAS, RCS, Light, Gear, Brakes, Abort, Custom01 - 10 
         public byte SOINumber;      //59  SOI Number (decimal format: sun-planet-moon e.g. 130 = kerbin, 131 = mun)
         public byte MaxOverHeat;    //60  Max part overheat (% percent)
@@ -858,8 +858,8 @@ namespace KSPSerialIO
 
                                 Vector3 maneuverVector = ActiveVessel.patchedConicSolver.maneuverNodes[0].GetBurnVector(ActiveVessel.orbit).normalized;
                                 double[] maneuverRelativeHeading = getOffsetFromHeading(ActiveVessel, maneuverVector);
-                                KSPSerialPort.VData.ManeuverPitch = ToFixedPoint(maneuverRelativeHeading[0]);
-                                KSPSerialPort.VData.ManeuverHeading = ToFixedPoint(maneuverRelativeHeading[1]);
+                                KSPSerialPort.VData.ManeuverPitch = ToScaledUInt(maneuverRelativeHeading[0]+180);
+                                KSPSerialPort.VData.ManeuverHeading = ToScaledUInt(maneuverRelativeHeading[1]);
                             }
                         }
                     }
@@ -868,16 +868,16 @@ namespace KSPSerialIO
                         Vessel targetVessel = FlightGlobals.fetch.VesselTarget.GetVessel();
                         Vector3 targetVector = (targetVessel.GetWorldPos3D() - ActiveVessel.GetWorldPos3D()).normalized;
                         double[] targetRelativeHeading = getOffsetFromHeading(ActiveVessel, targetVector);
-                        KSPSerialPort.VData.TargetPitch = ToFixedPoint(targetRelativeHeading[0]);
-                        KSPSerialPort.VData.TargetHeading = ToFixedPoint(targetRelativeHeading[1]);
+                        KSPSerialPort.VData.TargetPitch = ToScaledUInt(targetRelativeHeading[0]+180);
+                        KSPSerialPort.VData.TargetHeading = ToScaledUInt(targetRelativeHeading[1]);
                     }
 
                     //Debug.Log("KSPSerialIO: 5");
                     Quaternion attitude = updateHeadingPitchRollField(ActiveVessel);
 
-                    KSPSerialPort.VData.Roll = ToFixedPoint(((attitude.eulerAngles.z > 180) ? (attitude.eulerAngles.z - 360.0) : attitude.eulerAngles.z));
-                    KSPSerialPort.VData.Pitch = ToFixedPoint(((attitude.eulerAngles.x > 180) ? (360.0 - attitude.eulerAngles.x) : -attitude.eulerAngles.x));
-                    KSPSerialPort.VData.Heading = ToFixedPoint(attitude.eulerAngles.y);
+                    KSPSerialPort.VData.Roll = ToScaledUInt(((attitude.eulerAngles.z > 180) ? (attitude.eulerAngles.z - 360.0) : attitude.eulerAngles.z)+180);
+                    KSPSerialPort.VData.Pitch = ToScaledUInt(((attitude.eulerAngles.x > 180) ? (360.0 - attitude.eulerAngles.x) : -attitude.eulerAngles.x)+180);
+                    KSPSerialPort.VData.Heading = ToScaledUInt(attitude.eulerAngles.y);
 
                     Vector3 progradeVector = ActiveVessel.GetObtVelocity().normalized;
                     Vector3 normalVector = swapYZ(ActiveVessel.GetOrbit().GetOrbitNormal()).normalized;
@@ -887,14 +887,14 @@ namespace KSPSerialIO
                     double[] normalHeading = getOffsetFromHeading(ActiveVessel, normalVector);
                     double[] radialHeading = getOffsetFromHeading(ActiveVessel, radialVector);
                     double[] progradeSHeading = getOffsetFromHeading(ActiveVessel, progradeSVector);
-                    KSPSerialPort.VData.ProgradePitch = ToFixedPoint(progradeHeading[0]);
-                    KSPSerialPort.VData.ProgradeHeading = ToFixedPoint(progradeHeading[1]);
-                    KSPSerialPort.VData.NormalPitch = ToFixedPoint(normalHeading[0]);
-                    KSPSerialPort.VData.NormalHeading = ToFixedPoint(normalHeading[1]);
-                    KSPSerialPort.VData.RadialPitch = ToFixedPoint(radialHeading[0]);
-                    KSPSerialPort.VData.RadialHeading = ToFixedPoint(radialHeading[1]);
-                    KSPSerialPort.VData.ProgradeSPitch = ToFixedPoint(progradeSHeading[0]);
-                    KSPSerialPort.VData.ProgradeSHeading = ToFixedPoint(progradeSHeading[1]);
+                    KSPSerialPort.VData.ProgradePitch = ToScaledUInt(progradeHeading[0]+180);
+                    KSPSerialPort.VData.ProgradeHeading = ToScaledUInt(progradeHeading[1]);
+                    KSPSerialPort.VData.NormalPitch = ToScaledUInt(normalHeading[0]+180);
+                    KSPSerialPort.VData.NormalHeading = ToScaledUInt(normalHeading[1]);
+                    KSPSerialPort.VData.RadialPitch = ToScaledUInt(radialHeading[0]+180);
+                    KSPSerialPort.VData.RadialHeading = ToScaledUInt(radialHeading[1]);
+                    KSPSerialPort.VData.ProgradeSPitch = ToScaledUInt(progradeSHeading[0]+180);
+                    KSPSerialPort.VData.ProgradeSHeading = ToScaledUInt(progradeSHeading[1]);
 
                     KSPSerialPort.ControlStatus((int)enumAG.SAS, ActiveVessel.ActionGroups[KSPActionGroup.SAS]);
                     KSPSerialPort.ControlStatus((int)enumAG.RCS, ActiveVessel.ActionGroups[KSPActionGroup.RCS]);
@@ -1422,9 +1422,11 @@ namespace KSPSerialIO
             return SOI;
         }
 
-        private Int16 ToFixedPoint(double x)
+        private UInt16 ToScaledUInt(double x)
         {
-            return (Int16)(x * (1 << 6));
+            UInt16 result;
+            result = (UInt16)(x * 65535 / 360);
+            return result;
         }
 
         // this recursive stage look up stuff stolen and modified from KOS and others


### PR DESCRIPTION
I think this still needs a little bit of work, but wanted to open a PR now to get some feedback on the approach.

This change adds new fields for:
* Orbital Prograde, Normal and Radial pitch and heading.
* Surface Prograde pitch and heading.
* Target Prograde pitch and heading.
* Manuever node pitch and heading.

All of these are relative to the pitch, heading and roll of the active vessel, making rendering them on an FDAI or similar display fairly straightforward.

The existing pitch, heading and roll fields were sent as 4-byte floats, some in the range 0-360 and some in the range -180 to 180. This PR maps all angle data, including the existing fields, to an integer range 0-65535 and sends them as 2-byte unsigned ints. This still gives a resolution of about 0.05 degrees while saving space. Data packet size with this change is 209 bytes.

I've confirmed that the magnitude for the new fields is what I'd expect. But suspect they're inverted. It may be easier to render them on the arduino end if we first invert them before sending. But to be honest I'm still working on a working implementation for rendering this data. I'll have a much better opinion on that in the coming week or two.