### PR TITLE
Initialise ActiveVessel.

### DIFF
--- a/KSPSerialIO/KSPIO.cs
+++ b/KSPSerialIO/KSPIO.cs
@@ -676,7 +676,7 @@ namespace KSPSerialIO
         private double theTime = 0;
 
         public double refreshrate = 1.0f;
-        public static Vessel ActiveVessel;
+        public static Vessel ActiveVessel = new Vessel();
         public Guid VesselIDOld;
 
         IOResource TempR = new IOResource();


### PR DESCRIPTION
In KSP 1.1, the Update method throws a null reference exception because the ActiveVessel global is never initialised. Just initialising it with an empty Vessel when it's defined is enough to create a valid id field.